### PR TITLE
#5 add hot reloading

### DIFF
--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 set -e
 
+# git settings
+git config --global pull.rebase true
+git config --global remote.origin.prune true
+
 # if the .venv directory was mounted as a named volume, it needs the ownership changed
 sudo chown vscode .venv || true
 

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,14 +9,28 @@
             "type": "python",
             "request": "launch",
             "module": "pytest",
-            "justMyCode": true,
+            "justMyCode": false,
             "args": [
                 "--daemon",
                 "--daemon-watch-globs",
-                "./pytest_hot_reloading/*.py:./tests/*.py",
+                "./pytest_hot_reloading/daemon*.py:./pytest_hot_reloading/plugin.py",
                 "--daemon-ignore-watch-globs",
-                "./.venv/*"
+                "./.venv/*" // this is the default value
             ]
+        },
+        {
+            "name": "Pytest module (no args)",
+            "type": "python",
+            "request": "launch",
+            "module": "pytest",
+            "justMyCode": false
+        },
+        {
+            "name": "Pytest (no args)",
+            "type": "python",
+            "request": "launch",
+            "program": "/workspaces/pytest-hot-reloading/.venv/bin/pytest",
+            "justMyCode": false
         },
         {
             "name": "Python: Debug Unit Tests",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -16,7 +16,7 @@
             "justMyCode": false,
         },
         {
-            "name": "Test Server",
+            "name": "Pytest Daemon",
             "type": "python",
             "request": "launch",
             "module": "pytest",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -22,7 +22,11 @@
             "module": "pytest",
             "justMyCode": true,
             "args": [
-                "--daemon"
+                "--daemon",
+                "--daemon-watch-globs",
+                "./pytest_hot_reloading/*.py:./tests/*.py",
+                "--daemon-ignore-watch-globs",
+                "./.venv/*"
             ]
         }
     ]

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,17 +5,6 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "Python: Debug Unit Tests",
-            "type": "python",
-            "request": "launch",
-            "purpose": [
-                "debug-test",
-                "debug-in-terminal"
-            ],
-            "console": "integratedTerminal",
-            "justMyCode": false,
-        },
-        {
             "name": "Pytest Daemon",
             "type": "python",
             "request": "launch",
@@ -28,6 +17,17 @@
                 "--daemon-ignore-watch-globs",
                 "./.venv/*"
             ]
+        },
+        {
+            "name": "Python: Debug Unit Tests",
+            "type": "python",
+            "request": "launch",
+            "purpose": [
+                "debug-test",
+                "debug-in-terminal"
+            ],
+            "console": "integratedTerminal",
+            "justMyCode": false,
         }
     ]
 }

--- a/README.md
+++ b/README.md
@@ -1,2 +1,62 @@
-# pytest-hot-reloading
-A hot reloading pytest daemon, implemented as a plugin
+# A PyTest Hot Reloading Plugin
+A hot reloading pytest daemon, implemented as a plugin.
+
+This uses the jurigged library to watch files.
+
+If it takes less than 5 seconds to do all of the imports
+necessary to run a unit test, then you probably don't need this.
+
+## Installation
+TBD
+
+## Usage
+Add the plugin to the pytest arguments. Example using pyproject.toml:
+```toml
+[tool.pytest.ini_options]
+addopts = "-p pytest_hot_reloading.plugin"
+```
+
+When running pytest, the plugin will detect whether the daemon is running, and start it if is not.
+Note that a pid file is created to track the pid.
+
+Imports are not reran on subsequent runs, which can be a huge time saver.
+
+Currently, if you want to debug, you will want to run the daemon manually with debugging.
+This can easily be done in VS Code with the following launch profile:
+
+```json
+        {
+            "name": "Pytest Daemon",
+            "type": "python",
+            "request": "launch",
+            "module": "pytest",
+            "justMyCode": false,
+            "args": [
+                "--daemon",
+                //
+                // everything below this is optional
+                //
+                "--daemon-port",
+                "4852", // the default value
+                "--daemon-watch-globs",
+                "./*.py" // the default value
+                // "./my-project/*.py:./some-thing-else/*.py",  // example of colon separated globs
+                "--daemon-ignore-watch-globs",
+                "./.venv/*" // this is the default value, also colon separated globs
+            ]
+        },
+```
+
+The only reason you would need to limit the watched files is because the jurigged library
+opens every file it watches, so it can exhaust the open file limit if you have a lot of files.
+
+If the daemon is already running and you run pytest with `--daemon`, then the old one will be stopped
+and a new one will be started. Note that `pytest --daemon` is NOT how you run tests. It is only used to start
+the daemon.
+
+## Known Issues
+- This is early alpha
+- The jurigged library is not perfect and sometimes it gets in a bad state
+- Some libraries were not written with hot reloading in mind, and will not work without some changes.
+  There is going to be logic to work around other issues with other libraries, such as pytest-django's
+  mutation of the settings module that runs every session, but it hasn't been implemented yet.

--- a/pytest_hot_reloading/client.py
+++ b/pytest_hot_reloading/client.py
@@ -1,9 +1,6 @@
-import json
 import socket
 import sys
 import xmlrpc.client
-
-from pytest import Session
 
 from pytest_hot_reloading.daemon import PytestDaemon
 
@@ -25,8 +22,8 @@ class PytestClient:
 
         result = server.run_pytest(args)
 
-        stdout = result.get("stdout", "")
-        stderr = result.get("stderr", "")
+        stdout = result["stdout"].data.decode("utf-8")
+        stderr = result["stderr"].data.decode("utf-8")
 
         print(stdout, file=sys.stdout)
         print(stderr, file=sys.stderr)

--- a/pytest_hot_reloading/daemon.py
+++ b/pytest_hot_reloading/daemon.py
@@ -27,9 +27,6 @@ class PytestDaemon:
         watch_globs: str | None = None,
         ignore_watch_globs: str | None = None,
     ) -> None:
-        jurigged_path = which("jurigged")
-        if not jurigged_path:
-            raise Exception("jurigged is not installed. Install with 'pip install jurigged'")
         # start the daemon such that it will not close when the parent process closes
         if host == "localhost":
             args = [

--- a/pytest_hot_reloading/daemon.py
+++ b/pytest_hot_reloading/daemon.py
@@ -123,6 +123,7 @@ class PytestDaemon:
         sys.stderr = stderr
 
         try:
+            # args must omit the calling program
             pytest.main(["--color=yes"] + args)
         finally:
             # restore originals

--- a/pytest_hot_reloading/plugin.py
+++ b/pytest_hot_reloading/plugin.py
@@ -86,6 +86,11 @@ def _jurigged_logger(x: str) -> None:
 
 
 def _plugin_logic(session: Session) -> None:
+    """
+    The core plugin logic. This is where it splits based on whether we are the server or client.
+
+    In either case, the pytest logic will not continue after this.
+    """
     # if daemon is passed, then we are the daemon / server
     # if daemon is not passed, then we are the client
     daemon_port = int(session.config.option.daemon_port)
@@ -122,6 +127,18 @@ def _plugin_logic(session: Session) -> None:
 
 
 def _get_pattern_filters(session: Session) -> str | Callable[[str], bool]:
+    """
+    Jurigged takes in a pattern argument. The argument is either a glob string
+    or a function that returns True if the path passed into it should be watched.
+
+    This creates a function filter that will return True if the path matches.
+
+    The logic takes in the --daemon-watch-globs and --daemon-ignore-watch-globs options
+    and creates a function that will return True if the path matches the watch globs.
+
+    The seen_paths set is used to prevent duplicate paths from being watched and also
+    acts as a short circuit for paths that have already been seen.
+    """
     global seen_paths
 
     def normalize(glob: str) -> str:

--- a/pytest_hot_reloading/plugin.py
+++ b/pytest_hot_reloading/plugin.py
@@ -100,7 +100,12 @@ def _plugin_logic(session: Session) -> None:
         pytest_name = session.config.option.pytest_name
         client = PytestClient(daemon_port=daemon_port, pytest_name=pytest_name)
         # find the index of the first value that is not None
-        for idx, val in enumerate([pytest_name in x for x in sys.argv]):
+        for idx, val in enumerate(
+            [
+                x.endswith(pytest_name) or x.endswith(f"{pytest_name}/__main__.py")
+                for x in sys.argv
+            ]
+        ):
             if val:
                 pytest_name_index = idx
                 break

--- a/pytest_hot_reloading/plugin.py
+++ b/pytest_hot_reloading/plugin.py
@@ -1,30 +1,22 @@
-# A pytest plugin that starts the daemon if needed and forwards the args
-# to the daemon. The plugin will wait for the response from the daemon.
-# the daemon is communicated with using a tcp socket.
-# The daemon is started in a separate process and the plugin will wait
-# for the daemon to start before continuing.
-# if the daemon is busy on a test, subsequent tests will be queued
-# If the user runs the exact same test within 0.5 seconds, the daemon
-# will take that as a signal to restart proir to running the second
-# test. This plugin prevents the normal pytest logic from running.
-# Pytest can also be ran with the "--daemon" argument to start the daemon
-# in which case this isn't the client but the daemon itself. This
-# is useful if you want to run with debugging. If you run
-# the daemon with "--using-debug", then clients that run with the "--using-debug"
-# option will send the message to the debug client.
-
-
-# The plugin hook
+"""
+Pytest Hot Reloading plugin
+"""
+import fnmatch
 import os
+import re
 import sys
+from typing import Callable
 
-from pytest import Session
+import jurigged
+from pytest import Config, Item, Session
 
 from pytest_hot_reloading.client import PytestClient
 from pytest_hot_reloading.daemon import PytestDaemon
 
 # this is modified by the daemon so that the pytest_collection hooks does not run
 i_am_server = False
+
+seen_paths = set()
 
 
 def pytest_addoption(parser) -> None:
@@ -34,12 +26,6 @@ def pytest_addoption(parser) -> None:
         action="store_true",
         default=False,
         help="Start the daemon",
-    )
-    group.addoption(
-        "--using-debug",
-        action="store_true",
-        default=False,
-        help="Use the debug client port. This overrides --daemon-port.",
     )
     group.addoption(
         "--daemon-port",
@@ -59,6 +45,18 @@ def pytest_addoption(parser) -> None:
         default=(5 * 60),
         help="The timeout in seconds to wait on a test suite to finish",
     )
+    group.addoption(
+        "--daemon-watch-globs",
+        action="store",
+        default="./*.py",
+        help="The globs to watch for changes. This is a colon separated list of globs.",
+    )
+    group.addoption(
+        "--daemon-ignore-watch-globs",
+        action="store",
+        default="./.venv/*",
+        help="The globs to ignore for changes. This is a colon separated list of globs.",
+    )
 
 
 # list of pytest hooks
@@ -66,6 +64,10 @@ def pytest_addoption(parser) -> None:
 
 
 def pytest_collection(session: Session) -> None:
+    """
+    This hook is called by pytest and is one of the first hooks.
+    """
+    # early escapes
     if session.config.option.collectonly:
         return
     if i_am_server:
@@ -73,15 +75,25 @@ def pytest_collection(session: Session) -> None:
     _plugin_logic(session)
 
 
+def _jurigged_logger(x: str) -> None:
+    """
+    Jurigged behavior is to both print and log.
+
+    By default this creates duplicated output.
+
+    Pass in a no-op logger to prevent this.
+    """
+
+
 def _plugin_logic(session: Session) -> None:
-    # if daemon is passed, then we are the daemon
+    # if daemon is passed, then we are the daemon / server
     # if daemon is not passed, then we are the client
     daemon_port = int(session.config.option.daemon_port)
-    if session.config.option.using_debug:
-        daemon_port = 4853
     if session.config.option.daemon:
         # pytest prints out "collecting ...". The leading \r prevents that
         print("\rStarting daemon...")
+        pattern = _get_pattern_filters(session)
+        jurigged.watch(pattern=pattern, logger=_jurigged_logger)
         daemon = PytestDaemon(daemon_port=daemon_port)
         daemon.run_forever()
     else:
@@ -98,7 +110,59 @@ def _plugin_logic(session: Session) -> None:
                 "Could not find pytest name in args. "
                 "Check the configured name versus the actual name."
             )
-        client.run(sys.argv[pytest_name_index:])
+        client.run(sys.argv[pytest_name_index + 1 :])
 
         # dont do any more work. Don't let pytest continue
         os._exit(0)
+
+
+def _get_pattern_filters(session: Session) -> str | Callable[[str], bool]:
+    global seen_paths
+
+    def normalize(glob: str) -> str:
+        if glob.startswith("~"):
+            glob = os.path.expanduser(glob)
+        elif not glob.startswith("/"):
+            glob = os.path.abspath(glob)
+        if os.path.isdir(glob):
+            glob = os.path.join(glob, "*")
+        return glob
+
+    watch_globs = session.config.option.daemon_watch_globs.split(":")
+    regex_matches = [re.compile(fnmatch.translate(normalize(glob))).match for glob in watch_globs]
+
+    ignore_watch_globs = session.config.option.daemon_ignore_watch_globs
+    if ignore_watch_globs:
+        ignore_globs = session.config.option.daemon_ignore_watch_globs.split(":")
+        ignore_regex_matches = [
+            re.compile(fnmatch.translate(normalize(glob))).match for glob in ignore_globs
+        ]
+    else:
+        ignore_regex_matches = []
+
+    def matcher(filename) -> bool:
+        if filename in seen_paths:
+            return False
+        seen_paths.add(filename)
+        if any(regex_match(filename) for regex_match in regex_matches):
+            if not any(
+                ignore_regex_match(filename) for ignore_regex_match in ignore_regex_matches
+            ):
+                return True
+        return False
+
+    return matcher
+
+
+def pytest_collection_modifyitems(session: Session, config: Config, items: list[Item]) -> None:
+    """
+    This hooks is called by pytest after the collection phase.
+
+    This adds tests to the watch list automatically.
+    """
+    global seen_paths
+
+    for item in items:
+        if item.path and item.path not in seen_paths:
+            jurigged.watch(pattern=str(item.path))
+            seen_paths.add(item.path)

--- a/tests/test_samples.py
+++ b/tests/test_samples.py
@@ -10,4 +10,16 @@ def do_setup() -> None:
 def test_simple() -> None:
     do_setup()
 
-    assert 1 == 1
+    val = 1
+    other_val = 1
+
+    assert val == other_val, f"{val} != {other_val}"
+
+    # seeing a jurigged bug where doing a hard coded assertion of 1 == 1 doesn't quite work right:
+    # failing scenario
+    # assert 1 == 1
+    # assert 1 == 2
+    # assert 1 == 1  (again)
+    # This will still fail on the last assert, even though it should pass
+
+    print("foo")

--- a/tests/test_samples.py
+++ b/tests/test_samples.py
@@ -9,4 +9,5 @@ def do_setup() -> None:
 
 def test_simple() -> None:
     do_setup()
+
     assert 1 == 1


### PR DESCRIPTION
Addresses #5 and #8 

- Add sane git config defaults to `postCreateCommand`
- Have the pytest daemon launch config act as a reference (you don't need the watch globs)
- Add watch and ignore globs
- Update readme