### PR TITLE
Fix issue where profiling was failing due to forced exit

### DIFF
--- a/pytest_hot_reloading/plugin.py
+++ b/pytest_hot_reloading/plugin.py
@@ -75,6 +75,8 @@ def pytest_cmdline_main(config: Config) -> None:
     if i_am_server:
         return
     _plugin_logic(config)
+    # dont do any more work. Don't let pytest continue
+    return 1
 
 
 def _jurigged_logger(x: str) -> None:
@@ -167,9 +169,6 @@ def _plugin_logic(config: Config) -> None:
                 "Check the configured name versus the actual name."
             )
         client.run(sys.argv[pytest_name_index + 1 :])
-
-        # dont do any more work. Don't let pytest continue
-        os._exit(0)
 
 
 def _get_pattern_filters(config: Config) -> str | Callable[[str], bool]:

--- a/pytest_hot_reloading/plugin.py
+++ b/pytest_hot_reloading/plugin.py
@@ -76,7 +76,7 @@ def pytest_cmdline_main(config: Config) -> None:
         return
     _plugin_logic(config)
     # dont do any more work. Don't let pytest continue
-    return 1
+    return 0  # status code 0
 
 
 def _jurigged_logger(x: str) -> None:


### PR DESCRIPTION
When running the test logic through cProfile, nothing gets output because of the forced exit. We can use a `return 0` now to signal an early exit.