### PR TITLE
#14 improve client and subsequent call perf

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -97,6 +97,18 @@ six = ">=1.9.0"
 wcwidth = ">=0.1.4"
 
 [[package]]
+name = "cachetools"
+version = "5.3.0"
+description = "Extensible memoizing collections and decorators"
+category = "main"
+optional = false
+python-versions = "~=3.7"
+files = [
+    {file = "cachetools-5.3.0-py3-none-any.whl", hash = "sha256:429e1a1e845c008ea6c85aa35d4b98b65d6a9763eeef3e37e92728a12d1de9d4"},
+    {file = "cachetools-5.3.0.tar.gz", hash = "sha256:13dfddc7b8df938c21a940dfa6557ce6e94a2f1cdfa58eb90c805721d58f2c14"},
+]
+
+[[package]]
 name = "click"
 version = "8.1.3"
 description = "Composable command line interface toolkit"
@@ -515,4 +527,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "5502dfa557904a36d36af3ec29fc00dfc25b347231412f47256a32e3edb33184"
+content-hash = "80c57a29e5686573e503bb8d2acb4a128ca4f64d33b528d048a0c3585996eddf"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ line-length = 98
 
 [tool.poetry]
 name = "pytest-hot-reloading"
-version = "0.1.0-alpha.3"
+version = "0.1.0-alpha.4"
 description = ""
 authors = ["James Hutchison <jamesghutchison@proton.me>"]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ packages = [{ include = "pytest_hot_reloading" }]
 [tool.poetry.dependencies]
 python = "^3.10"
 jurigged = "^0.5.5"
+cachetools = "^5.3.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "^1.2.0"

--- a/pytest_hot_reloading/client.py
+++ b/pytest_hot_reloading/client.py
@@ -1,8 +1,7 @@
 import socket
 import sys
+import time
 import xmlrpc.client
-
-from pytest_hot_reloading.daemon import PytestDaemon
 
 
 class PytestClient:
@@ -25,7 +24,9 @@ class PytestClient:
         server_url = f"http://{self._daemon_host}:{self._daemon_port}"
         server = xmlrpc.client.ServerProxy(server_url)
 
+        start = time.time()
         result = server.run_pytest(args)
+        print(f"Daemon took {(time.time() - start):.3f} seconds to reply")
 
         stdout = result["stdout"].data.decode("utf-8")
         stderr = result["stderr"].data.decode("utf-8")
@@ -55,6 +56,8 @@ class PytestClient:
             self._start_daemon()
 
     def _start_daemon(self) -> None:
+        from pytest_hot_reloading.daemon import PytestDaemon
+
         # start the daemon
         PytestDaemon.start(
             host=self._daemon_host, port=self._daemon_port, pytest_name=self._pytest_name

--- a/pytest_hot_reloading/daemon.py
+++ b/pytest_hot_reloading/daemon.py
@@ -1,3 +1,4 @@
+import copy
 import os
 import re
 import socket
@@ -7,6 +8,7 @@ import time
 from xmlrpc.server import SimpleXMLRPCServer
 
 import pytest
+from cachetools import TTLCache
 
 
 class PytestDaemon:
@@ -118,11 +120,17 @@ class PytestDaemon:
         sys.stdout = stdout
         sys.stderr = stderr
 
+        import _pytest.main
+
         try:
             # args must omit the calling program
+            orig_main = _pytest.main._main
+            _pytest.main._main = _pytest_main
             pytest.main(["--color=yes"] + args)
         finally:
             # restore originals
+            _pytest.main._main = orig_main
+
             sys.stdout = stdout_bak
             sys.stderr = stderr_bak
 
@@ -144,3 +152,69 @@ class PytestDaemon:
     def _workaround_library_issues(self, args: list[str]) -> None:
         # load modules that workaround library issues, as needed
         pass
+
+
+session_cache = TTLCache(16, 500)
+
+
+def _pytest_main(config: pytest.Config, session: pytest.Session):
+    import _pytest.capture
+
+    _pytest.capture.CaptureManager.stop_global_capturing = lambda self: None
+    start_global_capturing = _pytest.capture.CaptureManager.start_global_capturing
+    resume_global_capture = _pytest.capture.CaptureManager.resume_global_capture
+
+    def start_global_capture_if_needed(self: _pytest.capture.CaptureManager):
+        if self._global_capturing is None:
+            start_global_capturing(self)
+        return resume_global_capture(self)
+
+    _pytest.capture.CaptureManager.resume_global_capture = start_global_capture_if_needed
+
+    seen_objects = set()
+
+    def best_effort_copy(item, depth_remaining=2):
+        seen_objects.add(id(item))
+        if depth_remaining <= 0:
+            return item
+        try:
+            item_copy = copy.copy(item)
+        except TypeError:
+            return item
+        if hasattr(item, "__dict__"):
+            for k, v in item.__dict__.items():
+                if id(v) in seen_objects:
+                    continue
+                seen_objects.add(id(v))
+                try:
+                    item_copy.__dict__[k] = copy.deepcopy(v)
+                except KeyboardInterrupt:
+                    raise
+                except Exception:
+                    item_copy.__dict__[k] = best_effort_copy(v, depth_remaining - 1)
+        return item_copy
+
+    session_key = tuple(config.args)
+    try:
+        items = session_cache[session_key]
+    except KeyError:
+        start = time.time()
+        config.hook.pytest_collection(session=session)
+        print(f"Pytest Daemon: Collection took {(time.time() - start):0.3f} seconds")
+        session_cache[session_key] = tuple(best_effort_copy(x) for x in session.items)
+    else:
+        print("Pytest Daemon: Using cached collection")
+        session.items = items
+        session.config = config
+        for i in items:
+            i.config = config
+            i.session = session
+            if i._request:
+                i._request._pyfuncitem = i
+    config.hook.pytest_runtestloop(session=session)
+
+    if session.testsfailed:
+        return pytest.ExitCode.TESTS_FAILED
+    elif session.testscollected == 0:
+        return pytest.ExitCode.NO_TESTS_COLLECTED
+    return None

--- a/pytest_hot_reloading/daemon.py
+++ b/pytest_hot_reloading/daemon.py
@@ -122,10 +122,12 @@ class PytestDaemon:
 
         import _pytest.main
 
+        # monkeypatch in the main that does test collection caching
+        orig_main = _pytest.main._main
+        _pytest.main._main = _pytest_main
+
         try:
             # args must omit the calling program
-            orig_main = _pytest.main._main
-            _pytest.main._main = _pytest_main
             pytest.main(["--color=yes"] + args)
         finally:
             # restore originals
@@ -158,6 +160,9 @@ session_cache = TTLCache(16, 500)
 
 
 def _pytest_main(config: pytest.Config, session: pytest.Session):
+    """
+    A monkey patched version of _pytest._main that caches test collection
+    """
     import _pytest.capture
 
     _pytest.capture.CaptureManager.stop_global_capturing = lambda self: None
@@ -171,42 +176,47 @@ def _pytest_main(config: pytest.Config, session: pytest.Session):
 
     _pytest.capture.CaptureManager.resume_global_capture = start_global_capture_if_needed
 
-    seen_objects = set()
-
     def best_effort_copy(item, depth_remaining=2):
-        seen_objects.add(id(item))
+        """
+        Copy test items. The items have references to modules and
+        other things that cannot be deep copied.
+        """
         if depth_remaining <= 0:
             return item
         try:
             item_copy = copy.copy(item)
         except TypeError:
             return item
+        # NodeKeywords is an example of an object without a __dict__
         if hasattr(item, "__dict__"):
             for k, v in item.__dict__.items():
-                if id(v) in seen_objects:
-                    continue
-                seen_objects.add(id(v))
                 try:
                     item_copy.__dict__[k] = copy.deepcopy(v)
                 except KeyboardInterrupt:
                     raise
-                except Exception:
+                except TypeError:
+                    # Non-pickelable objects
                     item_copy.__dict__[k] = best_effort_copy(v, depth_remaining - 1)
         return item_copy
 
+    # here config.args becomes basically the tests to run. Other arguments are omitted
+    # not 100% sure this is always the case
     session_key = tuple(config.args)
     try:
         items = session_cache[session_key]
     except KeyError:
+        # not in the cache, do test collection
         start = time.time()
         config.hook.pytest_collection(session=session)
         print(f"Pytest Daemon: Collection took {(time.time() - start):0.3f} seconds")
         session_cache[session_key] = tuple(best_effort_copy(x) for x in session.items)
     else:
         print("Pytest Daemon: Using cached collection")
+        # Assign the prior test items (tests to run) and config to the current session
         session.items = items
         session.config = config
         for i in items:
+            # Items have references to the config and the session
             i.config = config
             i.session = session
             if i._request:

--- a/pytest_hot_reloading/plugin.py
+++ b/pytest_hot_reloading/plugin.py
@@ -75,6 +75,8 @@ def pytest_cmdline_main(config: Config) -> None:
     if i_am_server:
         return
     _plugin_logic(config)
+    # dont do any more work. Don't let pytest continue
+    return 1
 
 
 def _jurigged_logger(x: str) -> None:
@@ -167,9 +169,6 @@ def _plugin_logic(config: Config) -> None:
                 "Check the configured name versus the actual name."
             )
         client.run(sys.argv[pytest_name_index + 1 :])
-
-        # dont do any more work. Don't let pytest continue
-        os._exit(0)
 
 
 def _get_pattern_filters(config: Config) -> str | Callable[[str], bool]:

--- a/pytest_hot_reloading/plugin.py
+++ b/pytest_hot_reloading/plugin.py
@@ -76,7 +76,7 @@ def pytest_cmdline_main(config: Config) -> None:
         return
     _plugin_logic(config)
     # dont do any more work. Don't let pytest continue
-    return 1
+    return 0  # status code 0
 
 
 def _jurigged_logger(x: str) -> None:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,3 +1,4 @@
+import re
 import socket
 import xmlrpc.client
 
@@ -29,7 +30,7 @@ class TestPytestClient:
 
         out, err = capsys.readouterr()
 
-        assert out == "stdout\n"
+        assert re.match(r"Daemon took \S+ seconds to reply\nstdout\n", out)
         assert err == "stderr\n"
 
     def test_aborting_should_close_the_socket(self) -> None:


### PR DESCRIPTION
Addresses #14 

This reduces the imports done by the client, as well as adds caching of the test collection. Effectively what was done:
- Imports not used by the client are done on-demand rather than top-of-module
- Jurigged modifications are also moved so the client isn't doing them
- Add caching of the pytest collection. This is based on the config's arguments, which as it turns out are the list of files to care about. For many projects, this is a very trivial improvement, but for some larger projects this can be a big savings. The cache is a TTL Cache so it expires shortly, but should be helpful for people frequently rerunning the same test.

This also addresses an issue where the system exit was preventing cProfile from working. Instead of directly exiting the process, this is returning the status code back to pytest