### PR TITLE
Add session ref count management

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ line-length = 98
 
 [tool.poetry]
 name = "pytest-hot-reloading"
-version = "0.1.0-alpha.4"
+version = "0.1.0-alpha.5"
 description = ""
 authors = ["James Hutchison <jamesghutchison@proton.me>"]
 readme = "README.md"

--- a/pytest_hot_reloading/daemon.py
+++ b/pytest_hot_reloading/daemon.py
@@ -1,17 +1,15 @@
 import copy
-import math
 import os
 import re
 import socket
 import subprocess
 import sys
 import time
-from collections import UserDict, deque
 from typing import Counter
 from xmlrpc.server import SimpleXMLRPCServer
 
 import pytest
-from cachetools import LRUCache, TTLCache
+from cachetools import TTLCache
 
 
 class PytestDaemon:

--- a/pytest_hot_reloading/daemon.py
+++ b/pytest_hot_reloading/daemon.py
@@ -222,7 +222,7 @@ def _pytest_main(config: pytest.Config, session: pytest.Session):
 
     _pytest.capture.CaptureManager.resume_global_capture = start_global_capture_if_needed
 
-    def best_effort_copy(item, depth_remaining=3):
+    def best_effort_copy(item, depth_remaining=2):
         """
         Copy test items. The items have references to modules and
         other things that cannot be deep copied.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import pytest
+
+
+@pytest.fixture(autouse=True, scope="session")
+def some_session_fixture():
+    yield


### PR DESCRIPTION
This fixes an issue where prior sessions had references to them still hanging around due to things like session level fixtures. This attempts to fix it by keep track of prior sessions, updating their dicts to the latest session, and then incorporating clean-up on the sessions that don't seem important.