### PR TITLE
Add `--stop-daemon` argument

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -6,6 +6,12 @@
             "type": "shell",
             "command": "poetry run dmypy check pytest_hot_reloading tests && poetry run ruff pytest_hot_reloading tests",
             "problemMatcher": []
+        },
+        {
+            "label": "Stop Daemon",
+            "type": "shell",
+            "command": "poetry run pytest --stop-daemon",
+            "problemMatcher": []
         }
     ]
 }

--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ If the daemon is already running and you run pytest with `--daemon`, then the ol
 and a new one will be started. Note that `pytest --daemon` is NOT how you run tests. It is only used to start
 the daemon.
 
+The daemon can be stopped with `pytest --stop-daemon`. This can be used if it gets into a bad state.
+
 ## Workarounds
 Libraries that use mutated globals may need a workaround to work with this plugin. The preferred
 route is to have the library update its code to not mutate globals in a test environment, or to


### PR DESCRIPTION
Addresses #23

Using `--stop-daemon` instead of `--daemon-stop` because its more intuitive version and because the `--daemon...` arguments apply to starting the daemon rather than the client