### PR TITLE
Performance improvements related to `best_effort_copy`

### DIFF
--- a/pytest_hot_reloading/daemon.py
+++ b/pytest_hot_reloading/daemon.py
@@ -253,16 +253,21 @@ def _manage_prior_session_garbage(session: pytest.Session) -> None:
             prior_session.__dict__ = session.__dict__
 
 
+# performance improvements
+# when doing a best_effort_copy, do not copy these attributes
 no_copy = {
     "_arg2fixturedefs",
     "_fixtureinfo",
     "keywords",
     "_fixturemanager",
     "_pyfuncitem",
-    # '_request'
 }
 
-use_best_effort_copy = {"_request"}
+# when doing a best_effort_copy, do not deep copy this
+# instead, force a best effort up to a given depth
+use_best_effort_copy = {
+    "_request",
+}
 
 
 def _pytest_main(config: pytest.Config, session: pytest.Session):


### PR DESCRIPTION
This updates the `best_effort_copy` logic to do less copying. I noticed when running a large group of tests, that there was a substantial delay before testing actually started. Digging into it and randomly pausing during this period, I added whatever was being copied to a list to not copy until the time was reduced by quite a bit. The only exception seemed to be `_request` which would result in errors after a couple reruns. Since `_request` was a deep object, I added a code path for forcing a limited depth copy.

It's been a while since I worked on this, but the background, if I remember correctly:
- The most expensive part of pytest start-up, outside of things like one-time database operations, is the session and test creation.
- Test sessions are cached and re-used based on what tests are ran
- You can't simply reference the session object because there's things inside that mutate. The session gets in a state of "I'm done", then pytest complains if you attempt to use it again. IIRC this state information becomes nested in sub-objects as well. For example, fixtures complaining that they were already cleaned up.
- You can't simply copy a session because of the nested state information
- You can't simply deep copy a session because it references modules and things that are non-serializable
- Best effort copy was created to try the copy the minimum needed to re-use sessions.
- I didn't realize how large these objects were when I wrote this earlier

Testing the performance, the improvement is substantial. Using the tests in this repo as a reference:
- Running without the plugin results in a failing test and execution is about 7.5 seconds
- Running with the plugin and daemon gets 5.6 seconds
- Re-running with the daemon gets 3.1 seconds

The failing test invokes more logic, exception handling, and introspection (errors are slow...) so it taking longer makes sense in this case. I disabled the check logic and its getting 6.6 seconds. I wouldn't expect an initial run with the daemon to be _faster_ than without, so its worth calling out this is curious behavior and may indicate something is not quite right.