### PR TITLE
Disable loading conftest when running as client

### DIFF
--- a/pytest_hot_reloading/plugin.py
+++ b/pytest_hot_reloading/plugin.py
@@ -9,8 +9,6 @@ from enum import Enum
 from pathlib import Path
 from typing import TYPE_CHECKING, Callable, Optional
 
-from pytest import Parser
-
 from pytest_hot_reloading.client import PytestClient
 
 # this is modified by the daemon so that the pytest_collection hooks does not run
@@ -19,7 +17,7 @@ i_am_server = False
 seen_paths: set[Path] = set()
 
 if TYPE_CHECKING:
-    from pytest import Config, Item, Session
+    from pytest import Config, Item, Parser, Session
 
 
 class EnvVariables(str, Enum):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,12 @@
+import time
+
 import pytest
 
 
 @pytest.fixture(autouse=True, scope="session")
 def some_session_fixture():
     yield
+
+
+# if conftest loading is happening, then even simple tests will see this delay
+time.sleep(2)


### PR DESCRIPTION
One of the challenges of writing this as a pytest plugin is finding all the ways pytest sneaks in work in unexpected places. In this case, pytest apparently loads conftest files extremely early.

This disables that loading when using the plugin as a client, which, depending on the project, can be substantial and heavily mitigates the benefits of using the hot reloader.

On a real world test with slow I/O exaggerating the test times, this reduced the test time for a test from 11.6 seconds to 3 seconds.