### PR TITLE
Only call jurigged.watch once

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ line-length = 98
 
 [tool.poetry]
 name = "pytest-hot-reloading"
-version = "0.1.0-alpha.12"
+version = "0.1.0-alpha.13"
 description = ""
 authors = ["James Hutchison <jamesghutchison@proton.me>"]
 readme = "README.md"

--- a/pytest_hot_reloading/plugin.py
+++ b/pytest_hot_reloading/plugin.py
@@ -317,8 +317,17 @@ def setup_jurigged(config: Config):
     pattern = _get_pattern_filters(config)
     # TODO: intelligently use poll versus watchman (https://github.com/JamesHutchison/pytest-hot-reloading/issues/16)
     jurigged.watch(
-        pattern=pattern, logger=_jurigged_logger, poll=(not config.option.daemon_use_watchman)
+        pattern=pattern,
+        logger=_jurigged_logger,
+        poll=(not config.option.daemon_use_watchman),
     )
+
+
+def watch_file(path: Path | str) -> None:
+    from jurigged import registry
+    from jurigged.utils import glob_filter
+
+    registry.auto_register(filter=glob_filter(str(path)))
 
 
 seen_files: set[str] = set()
@@ -351,7 +360,7 @@ def monkeypatch_fixture_marker(use_watchman: bool):
         # add fixture file to watched files
         if fixture_file not in seen_files:
             seen_files.add(fixture_file)
-            jurigged.watch(pattern=fixture_file, logger=_jurigged_logger, poll=(not use_watchman))
+            watch_file(fixture_file)
 
         fixtures.FixtureFunctionMarker = FixtureFunctionMarkerNew
         try:
@@ -467,13 +476,8 @@ def pytest_collection_modifyitems(session: Session, config: Config, items: list[
     used by the daemon.
     """
     global seen_paths
-    import jurigged
 
     for item in items:
         if item.path and item.path not in seen_paths:
-            jurigged.watch(
-                pattern=str(item.path),
-                logger=_jurigged_logger,
-                poll=(not config.option.daemon_use_watchman),
-            )
+            watch_file(item.path)
             seen_paths.add(item.path)

--- a/pytest_hot_reloading/plugin.py
+++ b/pytest_hot_reloading/plugin.py
@@ -334,7 +334,6 @@ seen_files: set[str] = set()
 
 
 def monkeypatch_fixture_marker(use_watchman: bool):
-    import jurigged
     import pytest
     from _pytest import fixtures
 


### PR DESCRIPTION
Noticed very high CPU usage using poll vs watchman. Looking at the code, it appears to create a new watcher every time `watch` is called, so this modifies the jurigged usage to only call `watch` once and then updates the registry used by the watcher.

The latest code update aligned the usage of `watch` so that polling was, by default, used for all files. Previously it was mixing poll and using the default of watchman. Tests and conftest files are automatically watched, so the use of watchman was hiding this inefficiency. Switching them to poll brought this out.