### PR TITLE
Add SQLAlchemy clean-up workaround

### DIFF
--- a/pytest_hot_reloading/workarounds.py
+++ b/pytest_hot_reloading/workarounds.py
@@ -66,6 +66,15 @@ def vscode_pytest_workaround() -> None:
     vscode_pytest.collected_tests_so_far = SetWithAppendRemove()
 
 
+@register_workaround("sqlalchemy")
+def sqlalchemy_cleanup_workaround() -> None:
+    from sqlalchemy import orm
+
+    yield
+
+    orm.close_all_sessions()
+
+
 def run_workarounds_pre() -> list[Generator]:
     in_progress_workarounds = []
     for module_name, workaround in workarounds:

--- a/pytest_hot_reloading/workarounds.py
+++ b/pytest_hot_reloading/workarounds.py
@@ -67,8 +67,8 @@ def vscode_pytest_workaround() -> None:
 
 
 @register_workaround("sqlalchemy")
-def sqlalchemy_cleanup_workaround() -> None:
-    from sqlalchemy import orm
+def sqlalchemy_cleanup_workaround() -> Generator:
+    from sqlalchemy import orm  # type: ignore
 
     yield
 


### PR DESCRIPTION
This adds a clean-up function for sqlalchemy that seems prudent. That said, I cannot vouch for its value, as I added this while debugging some issues with sessions being reused in async tests. I was still seeing sqlalchemy complaining about deleting sessions that weren't closed, so its not clear to me, yet, what is happening there.

I don't think there is any harm in having this.