### PR TITLE
Fix pytest collection cache not being copied from

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ line-length = 98
 
 [tool.poetry]
 name = "pytest-hot-reloading"
-version = "0.1.0-alpha.16"
+version = "0.1.0-alpha.17"
 description = ""
 authors = ["James Hutchison <jamesghutchison@proton.me>"]
 readme = "README.md"

--- a/pytest_hot_reloading/daemon.py
+++ b/pytest_hot_reloading/daemon.py
@@ -367,15 +367,15 @@ def _pytest_main(config: pytest.Config, session: pytest.Session):
     else:
         print("Pytest Daemon: Using cached collection")
         # Assign the prior test items (tests to run) and config to the current session
-        session.items = items  # type: ignore
+        session.items = tuple(best_effort_copy(x) for x in items)  # type: ignore
         num_tests_collected = len(items)
         session.config = config
-        for i in items:
+        for i in session.items:
             # Items have references to the config and the session
             i.config = config
             i.session = session
-            if i._request:
-                i._request._pyfuncitem = i
+            if i._request:  # type: ignore
+                i._request._pyfuncitem = i  # type: ignore
     config.hook.pytest_runtestloop(session=session)
     prior_sessions.add(session)
 


### PR DESCRIPTION
The pytest collection cache wasn't being copied from, resulting in the cached objects being inadvertently modified more than expected. This would manifest as strange errors when you ran something a third time or later, typically from fixture value reuse, and only on tests that had fixtures that were affected.

Deep copies cannot be created, so the cached objects are done using a best effort copy.