### PR TITLE
Update monkeypatch to fix (many) line numbers being off due to decorators

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ line-length = 98
 
 [tool.poetry]
 name = "pytest-hot-reloading"
-version = "0.1.0-alpha.17"
+version = "0.1.0-alpha.18"
 description = ""
 authors = ["James Hutchison <jamesghutchison@proton.me>"]
 readme = "README.md"

--- a/pytest_hot_reloading/plugin.py
+++ b/pytest_hot_reloading/plugin.py
@@ -256,15 +256,11 @@ def monkey_patch_jurigged_function_definition():
             return ast_func
 
         def stash(self, lineno=1, col_offset=0):
-            # monkeypatch: There's an off-by-one bug coming from somewhere in jurigged.
-            #              This affects replaced functions. When line numbers are wrong
-            #              the debugger and inspection logic doesn't work as expected.
+            # monkeypatch to fix line numbers from decorators: See https://github.com/breuleux/jurigged/issues/29
             if not isinstance(self.parent, OrigFunctionDefinition):
                 co = self.get_object()
-                if co and (delta := lineno - co.co_firstlineno):
-                    delta -= 1  # fix off-by-one
-                    if delta != 0:
-                        self.recode(jurigged_utils.shift_lineno(co, delta), use_cache=False)
+                if co and (delta := lineno - self.node.extent.lineno):
+                    self.recode(jurigged_utils.shift_lineno(co, delta), use_cache=False)
 
             return super(OrigFunctionDefinition, self).stash(lineno, col_offset)
 


### PR DESCRIPTION
This is a bit of a complicated problem and is not fully resolved, but this seems to be improvement over the simple adjustment in the previous logic. The old logic was doing a simple shift on the line numbers, and it seemed to fix the problem if a function was lower in the file after a function that had a single decorator.

For example:
```python
@pytest.fixture(autouse=True)
def setup(self):
    ...

def function_with_wrong_line_numbers(self):
    # the off by one fix in the previous code fixed me
```

 In all other cases the line numbers would be wrong. With this new fix, I'm seeing most cases being correct except for multiline decorators, but it's easily fixed by altering the function with the wrong line numbers.

```python
@somedecorator(

)
def this_function_will_offset_line_numbers_by_2(...):
    ...
```

See https://github.com/breuleux/jurigged/issues/29 for the full issue discussion.